### PR TITLE
chore: release 0.1.0-pre.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi"
-version = "0.1.0"
+version = "0.1.0-pre.0"
 edition = "2021"
 rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I think we are ready for the first pre-release, also added some sanity tests for semver since I forgot to include them in the last PR.