### PR TITLE
feat: add build info to metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,6 @@ fn ensure_current_version<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
 pub struct BuildInfo {
-    /// The hash of the contract WASM code.
-    pub wasm_hash: String,
     /// The compiler (versioned) that was used to build the contract.
     pub compiler: String,
     /// The build tool (versioned) that was used to build the contract.
@@ -81,6 +79,8 @@ pub struct AbiMetadata {
     /// The information about how this contract was built.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<BuildInfo>,
+    /// The SHA-256 hash of the contract WASM code in Base58 format.
+    pub wasm_hash: Option<String>,
     /// Other arbitrary metadata.
     #[serde(default, flatten, skip_serializing_if = "HashMap::is_empty")]
     pub other: HashMap<String, String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,19 @@ fn ensure_current_version<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
+pub struct BuildInfo {
+    /// The hash of the contract WASM code.
+    pub wasm_hash: String,
+    /// The compiler (versioned) that was used to build the contract.
+    pub compiler: String,
+    /// The build tool (versioned) that was used to build the contract.
+    pub builder: String,
+    /// The docker image (versioned) where the contract was built.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
 pub struct AbiMetadata {
     /// The name of the smart contract.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -65,6 +78,9 @@ pub struct AbiMetadata {
     /// The authors of the smart contract.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub authors: Vec<String>,
+    /// The information about how this contract was built.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build: Option<BuildInfo>,
     /// Other arbitrary metadata.
     #[serde(default, flatten, skip_serializing_if = "HashMap::is_empty")]
     pub other: HashMap<String, String>,


### PR DESCRIPTION
Some of the metadata could be made more type safe (e.g. `compiler` should be `(Language, Version)` formatted with a whitespace inbetween), but I think it is fine as is for now.