### PR TITLE
chore: release 0.2.0-pre.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi"
-version = "0.2.0-pre.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi"
-version = "0.1.0-pre.0"
+version = "0.2.0-pre.0"
 edition = "2021"
 rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,14 @@ pub mod __private;
 // Keep in sync with SCHEMA_VERSION below.
 const SCHEMA_SEMVER: Version = Version {
     major: 0,
-    minor: 1,
+    minor: 2,
     patch: 0,
     pre: semver::Prerelease::EMPTY,
     build: semver::BuildMetadata::EMPTY,
 };
 
 /// Current version of the ABI schema format.
-pub const SCHEMA_VERSION: &str = "0.1.0";
+pub const SCHEMA_VERSION: &str = "0.2.0";
 
 /// Contract ABI.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
Bumping schema version to 0.2.0 after the recent changes.

Also, just noticed that we never released 0.1.0. Should I promote 0.1.0-pre.0 to 0.1.0 since it seemed to work fine or is this not a big deal?