### PR TITLE
fix: use `any_of` instead of `one_of` for `AbiType`

### DIFF
--- a/metaschema/near-abi-0.2.0-schema.json
+++ b/metaschema/near-abi-0.2.0-schema.json
@@ -257,7 +257,7 @@
       ]
     },
     "AbiType": {
-      "oneOf": [
+      "anyOf": [
         {
           "description": "A JSON Schema.",
           "anyOf": [

--- a/metaschema/near-abi-current-schema.json
+++ b/metaschema/near-abi-current-schema.json
@@ -257,7 +257,7 @@
       ]
     },
     "AbiType": {
-      "oneOf": [
+      "anyOf": [
         {
           "description": "A JSON Schema.",
           "anyOf": [

--- a/near-abi/src/lib.rs
+++ b/near-abi/src/lib.rs
@@ -245,7 +245,7 @@ impl JsonSchema for AbiType {
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> Schema {
         schemars::schema::Schema::Object(schemars::schema::SchemaObject {
             subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
-                one_of: Some(vec![
+                any_of: Some(vec![
                     <Schema as schemars::JsonSchema>::json_schema(gen),
                     Schema::Bool(true), // TODO: Narrow to BorshSchemaContainer once it derives JsonSchema
                 ]),


### PR DESCRIPTION
Confused `any_of` with `one_of` when I was writing this manual implementation. ABIs are unvalidatable on https://www.jsonschemavalidator.net/ with `one_of` since it is restrictive to match **exactly one** branch.