### PR TITLE
feat: get rid of `is_*` fields

### DIFF
--- a/metaschema/Cargo.toml
+++ b/metaschema/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 [dependencies]
 anyhow = "1"
 near-abi = { path = "../near-abi" }
-schemars = { version = "0.8.8", features = ["impl_json_schema"] }
+schemars = { version = "0.8.11", features = ["impl_json_schema"] }
 serde_json = "1"

--- a/metaschema/near-abi-current-schema.json
+++ b/metaschema/near-abi-current-schema.json
@@ -159,11 +159,28 @@
     },
     "AbiFunctionModifier": {
       "description": "Function can have multiple modifiers that can change its semantics.",
-      "type": "string",
-      "enum": [
-        "init",
-        "private",
-        "payable"
+      "oneOf": [
+        {
+          "description": "Init functions can be used to initialize the state of the contract.",
+          "type": "string",
+          "enum": [
+            "init"
+          ]
+        },
+        {
+          "description": "Private functions can only be called from the contract containing them. Usually, when a contract has to have a callback for a remote cross-contract call, this callback method should only be called by the contract itself.",
+          "type": "string",
+          "enum": [
+            "private"
+          ]
+        },
+        {
+          "description": "Payable functions can accept token transfer together with the function call. This is done so that contracts can define a fee in tokens that needs to be payed when they are used.",
+          "type": "string",
+          "enum": [
+            "payable"
+          ]
+        }
       ]
     },
     "AbiJsonParameter": {

--- a/metaschema/near-abi-current-schema.json
+++ b/metaschema/near-abi-current-schema.json
@@ -80,6 +80,7 @@
       "description": "ABI of a single function.",
       "type": "object",
       "required": [
+        "kind",
         "name"
       ],
       "properties": {
@@ -108,21 +109,20 @@
             "null"
           ]
         },
-        "is_init": {
-          "description": "Whether function can be used to initialize the state.",
-          "type": "boolean"
+        "kind": {
+          "description": "Function kind that regulates whether the function has to be invoked from a transaction.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AbiFunctionKind"
+            }
+          ]
         },
-        "is_payable": {
-          "description": "Whether function is accepting $NEAR.",
-          "type": "boolean"
-        },
-        "is_private": {
-          "description": "Whether function can only accept calls from self (current account).",
-          "type": "boolean"
-        },
-        "is_view": {
-          "description": "Whether function does not modify the state.",
-          "type": "boolean"
+        "modifiers": {
+          "description": "List of modifiers affecting the function.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AbiFunctionModifier"
+          }
         },
         "name": {
           "type": "string"
@@ -148,6 +148,23 @@
         }
       },
       "additionalProperties": false
+    },
+    "AbiFunctionKind": {
+      "description": "Function kind regulates whether this function's invocation requires a transaction (so-called call functions) or not (view functions).",
+      "type": "string",
+      "enum": [
+        "view",
+        "call"
+      ]
+    },
+    "AbiFunctionModifier": {
+      "description": "Function can have multiple modifiers that can change its semantics.",
+      "type": "string",
+      "enum": [
+        "init",
+        "private",
+        "payable"
+      ]
     },
     "AbiJsonParameter": {
       "description": "Information about a single named JSON function parameter.",

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -12,7 +12,7 @@ description = "NEAR smart contract ABI primitives"
 borsh = { version = "0.9", features = ["const-generics"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
-schemars = { version = "0.8.8", features = ["impl_json_schema"] }
+schemars = { version = "0.8.11", features = ["impl_json_schema"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/near-abi/src/lib.rs
+++ b/near-abi/src/lib.rs
@@ -106,18 +106,11 @@ pub struct AbiFunction {
     /// Human-readable documentation parsed from the source file.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub doc: Option<String>,
-    /// Whether function does not modify the state.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub is_view: bool,
-    /// Whether function can be used to initialize the state.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub is_init: bool,
-    /// Whether function is accepting $NEAR.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub is_payable: bool,
-    /// Whether function can only accept calls from self (current account).
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub is_private: bool,
+    /// Function kind that regulates whether the function has to be invoked from a transaction.
+    pub kind: AbiFunctionKind,
+    /// List of modifiers affecting the function.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modifiers: Vec<AbiFunctionModifier>,
     /// Type identifiers of the function parameters.
     #[serde(default, skip_serializing_if = "AbiParameters::is_empty")]
     pub params: AbiParameters,
@@ -130,6 +123,31 @@ pub struct AbiFunction {
     /// Return type identifier.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<AbiType>,
+}
+
+/// Function kind regulates whether this function's invocation requires a transaction (so-called
+/// call functions) or not (view functions).
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AbiFunctionKind {
+    View,
+    Call,
+}
+
+/// Function can have multiple modifiers that can change its semantics.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AbiFunctionModifier {
+    /// Init functions can be used to initialize the state of the contract.
+    Init,
+    /// Private functions can only be called from the contract containing them. Usually, when a
+    /// contract has to have a callback for a remote cross-contract call, this callback method
+    /// should only be called by the contract itself.
+    Private,
+    /// Payable functions can accept token transfer together with the function call.
+    /// This is done so that contracts can define a fee in tokens that needs to be payed when
+    /// they are used.
+    Payable,
 }
 
 /// A list of function parameters sharing the same serialization type.
@@ -498,10 +516,6 @@ mod borsh_serde {
             .map(|(k, HelperDefinition(v))| (k, v))
             .collect())
     }
-}
-
-fn is_false(b: &bool) -> bool {
-    !b
 }
 
 #[cfg(test)]

--- a/near-abi/src/lib.rs
+++ b/near-abi/src/lib.rs
@@ -127,7 +127,7 @@ pub struct AbiFunction {
 
 /// Function kind regulates whether this function's invocation requires a transaction (so-called
 /// call functions) or not (view functions).
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum AbiFunctionKind {
     View,
@@ -135,7 +135,7 @@ pub enum AbiFunctionKind {
 }
 
 /// Function can have multiple modifiers that can change its semantics.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum AbiFunctionModifier {
     /// Init functions can be used to initialize the state of the contract.

--- a/near-abi/src/lib.rs
+++ b/near-abi/src/lib.rs
@@ -13,14 +13,14 @@ pub mod __private;
 // Keep in sync with SCHEMA_VERSION below.
 const SCHEMA_SEMVER: Version = Version {
     major: 0,
-    minor: 2,
+    minor: 3,
     patch: 0,
     pre: semver::Prerelease::EMPTY,
     build: semver::BuildMetadata::EMPTY,
 };
 
 /// Current version of the ABI schema format.
-pub const SCHEMA_VERSION: &str = "0.2.0";
+pub const SCHEMA_VERSION: &str = "0.3.0";
 
 /// Contract ABI.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
Fixes #13 

Comes with a schemars update since a small bug with rustdocs in enums was fixed in 0.8.11