### PR TITLE
fix: loosen schemars version requirement

### DIFF
--- a/metaschema/Cargo.toml
+++ b/metaschema/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 [dependencies]
 anyhow = "1"
 near-abi = { path = "../near-abi" }
-schemars = { version = "0.8.11", features = ["impl_json_schema"] }
+schemars = { version = "0.8", features = ["impl_json_schema"] }
 serde_json = "1"

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -12,7 +12,7 @@ description = "NEAR smart contract ABI primitives"
 borsh = { version = "0.9", features = ["const-generics"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
-schemars = { version = "0.8.11", features = ["impl_json_schema"] }
+schemars = { version = "0.8", features = ["impl_json_schema"] }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
Caused a breakage. Don't think there is any reason we need to have this as a minimum patch version, do we?