### PR TITLE
chore: release v0.4.1

### DIFF
--- a/near-abi/CHANGELOG.md
+++ b/near-abi/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.0...near-abi-v0.4.1) - 2023-10-30
+
+### Other
+- pin `borsh` version to avoid compile errors ([#28](https://github.com/near/near-abi-rs/pull/28))

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.66.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-abi`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.0...near-abi-v0.4.1) - 2023-10-30

### Other
- pin `borsh` version to avoid compile errors ([#28](https://github.com/near/near-abi-rs/pull/28))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).