### PR TITLE
chore: release v0.4.2

### DIFF
--- a/near-abi/CHANGELOG.md
+++ b/near-abi/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.1...near-abi-v0.4.2) - 2024-01-21
+
+### Other
+- `borsh` version range update ([#31](https://github.com/near/near-abi-rs/pull/31))
+
 ## [0.4.1](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.0...near-abi-v0.4.1) - 2023-10-30
 
 ### Other

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.66.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-abi`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.1...near-abi-v0.4.2) - 2024-01-21

### Other
- `borsh` version range update ([#31](https://github.com/near/near-abi-rs/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).