### PR TITLE
chore: release v0.4.3

### DIFF
--- a/near-abi/CHANGELOG.md
+++ b/near-abi/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.2...near-abi-v0.4.3) - 2024-04-30
+
+### Other
+- borsh update up to `<1.6.0` ([#34](https://github.com/near/near-abi-rs/pull/34))
+
 ## [0.4.2](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.1...near-abi-v0.4.2) - 2024-01-21
 
 ### Other

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.66.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-abi`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.2...near-abi-v0.4.3) - 2024-04-30

### Other
- borsh update up to `<1.6.0` ([#34](https://github.com/near/near-abi-rs/pull/34))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).