### PR TITLE
fix: Extended the range of supported borsh-rs versions up to 1.6.0 release (HEADS UP: the convention for names of enum variants has changed and now include two underscores between the enum name and the enum variant name)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,13 +25,6 @@ jobs:
           toolchain: ${{ env.RUST_MSRV }}
           default: true
 
-      - name: downgrade `toml_datetime` crate to support older Rust toolchain
-        if: ${{ env.RUST_MSRV }} == '1.66.0' 
-        run: |
-          cargo update -p borsh --precise 1.1.0
-          cargo update -p toml_edit --precise 0.20.2
-          cargo update -p toml_datetime --precise 0.6.3
-
       - run: cargo check
 
   tests:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,10 @@ jobs:
           toolchain: ${{ env.RUST_MSRV }}
           default: true
 
+      - name: downgrade crates to support older Rust toolchain
+        run: |
+          cargo update -p indexmap@2.12.1 --precise 2.11.4
+
       - run: cargo check
 
   tests:

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -2,14 +2,14 @@
 name = "near-abi"
 version = "0.4.3"
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.77.0"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/near/near-abi-rs"
 description = "NEAR smart contract ABI primitives"
 
 [dependencies]
-borsh = { version = ">=1.1.0,<1.7.0", features = ["unstable__schema", "derive"] }
+borsh = { version = ">=1.6.0,<1.7.0", features = ["unstable__schema", "derive"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 schemars = { version = "0.8.11", features = ["impl_json_schema"] }

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/near/near-abi-rs"
 description = "NEAR smart contract ABI primitives"
 
 [dependencies]
-borsh = { version = ">=1.1.0,<1.6.0", features = ["unstable__schema", "derive"] }
+borsh = { version = ">=1.1.0,<1.7.0", features = ["unstable__schema", "derive"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 schemars = { version = "0.8.11", features = ["impl_json_schema"] }

--- a/near-abi/src/lib.rs
+++ b/near-abi/src/lib.rs
@@ -576,8 +576,8 @@ mod tests {
                 &Definition::Enum {
                     tag_width: 1,
                     variants: vec![
-                        (0, "_Left".to_string(), "Either_Left".to_string()),
-                        (1, "_Right".to_string(), "Either_Right".to_string())
+                        (0, "_Left".to_string(), "Either___Left".to_string()),
+                        (1, "_Right".to_string(), "Either___Right".to_string())
                     ]
                 }
             );

--- a/near-abi/src/snapshots/near_abi__tests__serde_abitype_borsh_enum.snap
+++ b/near-abi/src/snapshots/near_abi__tests__serde_abitype_borsh_enum.snap
@@ -14,22 +14,22 @@ expression: expected_json_str
             [
               0,
               "_Left",
-              "Either_Left"
+              "Either___Left"
             ],
             [
               1,
               "_Right",
-              "Either_Right"
+              "Either___Right"
             ]
           ]
         }
       },
-      "Either_Left": {
+      "Either___Left": {
         "Struct": [
           "u32"
         ]
       },
-      "Either_Right": {
+      "Either___Right": {
         "Struct": [
           "u32"
         ]


### PR DESCRIPTION
See more details in https://github.com/near/borsh-rs/pull/361