### PR TITLE
chore: release v0.4.4

### DIFF
--- a/near-abi/CHANGELOG.md
+++ b/near-abi/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.3...near-abi-v0.4.4) - 2025-11-28
+
+### Fixed
+
+- Bumped minimal borsh-rs version to 1.6.0 (HEADS UP: the convention for names of enum variants has changed and now include two underscores between the enum name and the enum variant name) ([#36](https://github.com/near/near-abi-rs/pull/36))
+
 ## [0.4.3](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.2...near-abi-v0.4.3) - 2024-04-30
 
 ### Other

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.77.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-abi`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.3...near-abi-v0.4.4) - 2025-11-28

### Fixed

- Bumped minimal borsh-rs version to 1.6.0 (HEADS UP: the convention for names of enum variants has changed and now include two underscores between the enum name and the enum variant name) ([#36](https://github.com/near/near-abi-rs/pull/36))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).