### PR TITLE
chore: update to Rust edition 2024 and schemars 0.8.22

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,15 +19,9 @@ jobs:
           echo "RUST_MSRV=$RUST_MSRV" >> $GITHUB_ENV
 
       - name: "Install ${{ env.RUST_MSRV }} toolchain (MSRV)"
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ env.RUST_MSRV }}
-          default: true
-
-      - name: downgrade crates to support older Rust toolchain
-        run: |
-          cargo update -p indexmap@2.12.1 --precise 2.11.4
 
       - run: cargo check
 
@@ -38,6 +32,9 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Run Tests
         run: cargo test
 
@@ -47,6 +44,11 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: Check Formatting
         run: cargo fmt -- --check
@@ -60,6 +62,9 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install json-schema-compatibility-checker
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = [
     "near-abi",
     "metaschema"
 ]
-resolver = "2"
+resolver = "3"

--- a/metaschema/Cargo.toml
+++ b/metaschema/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "metaschema-gen"
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.56.0"
+edition = "2024"
+rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
 anyhow = "1"
 near-abi = { path = "../near-abi" }
-schemars = { version = "0.8.11", features = ["impl_json_schema"] }
+schemars = { version = "0.8.22", features = ["impl_json_schema"] }
 serde_json = "1"

--- a/metaschema/src/main.rs
+++ b/metaschema/src/main.rs
@@ -1,8 +1,8 @@
 use near_abi::AbiRoot;
 
 fn main() -> anyhow::Result<()> {
-    let mut gen = schemars::gen::SchemaGenerator::default();
-    let schema = gen.root_schema_for::<AbiRoot>();
+    let mut schema_gen = schemars::r#gen::SchemaGenerator::default();
+    let schema = schema_gen.root_schema_for::<AbiRoot>();
     println!("{}", serde_json::to_string_pretty(&schema)?);
     Ok(())
 }

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "near-abi"
 version = "0.4.4"
-edition = "2021"
-rust-version = "1.77.0"
+edition = "2024"
+rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/near/near-abi-rs"
@@ -12,7 +12,7 @@ description = "NEAR smart contract ABI primitives"
 borsh = { version = ">=1.6.0,<1.7.0", features = ["unstable__schema", "derive"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
-schemars = { version = "0.8.11", features = ["impl_json_schema"] }
+schemars = { version = "0.8.22", features = ["impl_json_schema"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/near-abi/src/private.rs
+++ b/near-abi/src/private.rs
@@ -1,5 +1,5 @@
 use super::{
-    ensure_current_version, AbiBody, AbiFunction, AbiMetadata, AbiRoot, RootSchema, SCHEMA_VERSION,
+    AbiBody, AbiFunction, AbiMetadata, AbiRoot, RootSchema, SCHEMA_VERSION, ensure_current_version,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -31,8 +31,8 @@ impl ChunkedAbiEntry {
         let mut schema_version = None;
         let mut functions = Vec::<AbiFunction>::new();
 
-        let mut gen = schemars::gen::SchemaGenerator::default();
-        let definitions = gen.definitions_mut();
+        let mut schema_gen = schemars::r#gen::SchemaGenerator::default();
+        let definitions = schema_gen.definitions_mut();
 
         let mut unexpected_versions = std::collections::BTreeSet::new();
 
@@ -70,7 +70,7 @@ impl ChunkedAbiEntry {
             schema_version: schema_version.unwrap(),
             body: AbiBody {
                 functions,
-                root_schema: gen.into_root_schema_for::<String>(),
+                root_schema: schema_gen.into_root_schema_for::<String>(),
             },
         })
     }


### PR DESCRIPTION
## Summary

Update Rust edition to 2024 and upgrade schemars to the latest 0.8.x release.

### Changes

- **Rust Edition**: Update from 2021 to 2024
- **MSRV**: Update `rust-version` to 1.85.0 (required for edition 2024)
- **schemars**: Update from 0.8.11 to 0.8.22 (includes [Rust 2024 compatibility fix](https://github.com/GREsau/schemars/pull/378))
- **Code**: Use `r#gen` to escape the reserved `gen` keyword in Rust 2024
- **CI**: Replace deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain`
- **CI**: Remove `indexmap` downgrade workaround (no longer needed with updated MSRV)

### Backward Compatibility

- No changes to the generated JSON schema format
- No changes to the public API
- Existing code using `near-abi` continues to work unchanged