### PR TITLE
chore: release v0.4.5

### DIFF
--- a/near-abi/CHANGELOG.md
+++ b/near-abi/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.4...near-abi-v0.4.5) - 2026-02-17
+
+### Other
+
+- update to Rust edition 2024 and schemars 0.8.22 ([#40](https://github.com/near/near-abi-rs/pull/40))
+
 ## [0.4.4](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.3...near-abi-v0.4.4) - 2025-11-28
 
 ### Fixed

--- a/near-abi/Cargo.toml
+++ b/near-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-abi"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-abi`: 0.4.4 -> 0.4.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.5](https://github.com/near/near-abi-rs/compare/near-abi-v0.4.4...near-abi-v0.4.5) - 2026-02-17

### Other

- update to Rust edition 2024 and schemars 0.8.22 ([#40](https://github.com/near/near-abi-rs/pull/40))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).