### PR TITLE
ci: trusted publishing to crates.io via release-plz + OIDC

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,74 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release-pr)
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write
+      attestations: write
+    # Never cancel an in-flight publish — half-published releases are worse than waiting.
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release)
+        id: release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # release-plz doesn't expose the produced .crate paths, so re-package locally.
+      # The crate tarballs are reproducible from the same commit, so the attestations
+      # still bind the published artifacts to this run. Publishable members listed
+      # explicitly with -p flags.
+      - name: Re-package crates for attestation
+        if: steps.release-plz.outputs.releases_created == 'true'
+        run: cargo package --no-verify -p near-abi
+      - name: Attest build provenance
+        if: steps.release-plz.outputs.releases_created == 'true'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: target/package/*.crate

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,22 +79,3 @@ jobs:
 
       - name: Check that Meta-schema is Backward Compatible
         run: pip install semver && python .github/check_metaschema_compatibility.py
-
-  release-plz:
-    runs-on: ubuntu-latest
-    needs: [msrv-check, tests, lint, check-metaschema]
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.MY_GITHUB_TOKEN }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
-        env:
-          # https://release-plz.ieni.dev/docs/github/trigger
-          GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,14 @@
+[workspace]
+changelog_update = true
+git_tag_enable = true
+git_release_enable = true
+git_release_type = "auto"
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""


### PR DESCRIPTION
OIDC trusted publishing via release-plz. Drops `CARGO_REGISTRY_TOKEN`, adds attestations. Pattern matches near/near-slip10#3.

Workspace has 1 publishable crate, so it needs crates.io trusted publisher registration before next release: `near-abi`, workflow `release-plz.yml`. (`metaschema-gen` is `publish = false`.)

Refs near/devex#45